### PR TITLE
Update main README.md for new paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,18 @@ This project contains the Slic3r profiles for the 3D printers produced by Prusa 
 * [Slic3r settings 3mm - Settings for the Prusa i3 with a 3mm filament extruder](https://github.com/prusa3d/Slic3r-settings/tree/master/old/Slic3r%20settings%203mm)
 
 To apply these settings, you have to copy the particular github folder
-([Slic3r settings MK2, MK2S, MK2MM and MK3](https://github.com/prusa3d/Slic3r-settings/tree/master/Slic3r%20settings%20MK2S%20MK2MM%20and%20MK3) / 
-[Slic3r settings 175](https://github.com/prusa3d/Slic3r-settings/tree/master/old/Slic3r%20settings%20175) / 
+([Slic3r settings MK2, MK2S, MK2MM and MK3](https://github.com/prusa3d/Slic3r-settings/tree/master/Slic3r%20settings%20MK2S%20MK2MM%20and%20MK3) /
+[Slic3r settings 175](https://github.com/prusa3d/Slic3r-settings/tree/master/old/Slic3r%20settings%20175) /
 [Slic3r settings 3mm](https://github.com/prusa3d/Slic3r-settings/tree/master/old/Slic3r%20settings%203mm))
-into a local folder, where Slic3r will find it. The destination depends on your operating system:
+into a local folder, where Slic3r will find it. The destination depends on your operating system and Slic3r version:
+
+__Slic3r PE 1.38.4 and later__
+
+ * Windows: "C:\Users\your_user_name\AppData\Roaming\Slic3rPE" or "C:\Documents and Settings\your_user_name\Application Data\Slic3rPE"
+ * Mac: ~/Library/Application\ Support/Slic3rPE/
+ * Unix / Linux: "~/.Slic3rPE/"
+
+__All other versions__
 
 * Windows: "C:\Users\your_user_name\AppData\Roaming\Slic3r\" or "C:\Documents and Settings\your_user_name\Application Data\Slic3r\"
 * Mac: "~/Library/Application Support/Slic3r/"


### PR DESCRIPTION
In Slic3r PE 1.38.4 a new config path was introduced.  This patch adds
these new paths to the README, whilst retaining the reference to the
originals.