### PR TITLE
0.1.4 Fixed MK3 printer_variant fields, MK2 name

### DIFF
--- a/live/PrusaResearch/0.1.4.ini
+++ b/live/PrusaResearch/0.1.4.ini
@@ -1,0 +1,1039 @@
+# Print profiles for the Prusa Research printers.
+
+[vendor]
+# Vendor name will be shown by the Config Wizard.
+name = Prusa Research
+# Configuration version of this file. Config file will only be installed, if the config_version differs.
+# This means, the server may force the Slic3r configuration to be downgraded.
+config_version = 0.1.4
+# Where to get the updates from?
+config_update_url = https://raw.githubusercontent.com/prusa3d/Slic3r-settings/master/live/PrusaResearch/
+
+# The printer models will be shown by the Configuration Wizard in this order,
+# also the first model installed & the first nozzle installed will be activated after install.
+#TODO: One day we may differentiate variants of the nozzles / hot ends,
+#for example by the melt zone size, or whether the nozzle is hardened.
+# Printer model name will be shown by the installation wizard.
+[printer_model:MK3]
+name = Original Prusa i3 MK3
+variants = 0.4; 0.25; 0.6
+
+[printer_model:MK2S]
+name = Original Prusa i3 MK2S, MK2.5
+variants = 0.4; 0.25; 0.6
+
+[printer_model:MK2SMM]
+name = Original Prusa i3 MK2SMM
+variants = 0.4; 0.6
+
+# All presets starting with asterisk, for example *common*, are intermediate and they will
+# not make it into the user interface.
+
+# Common print preset, mostly derived from MK2 single material with a 0.4mm nozzle.
+# All other print presets will derive from the *common* print preset.
+[print:*common*]
+avoid_crossing_perimeters = 0
+bridge_acceleration = 1000
+bridge_angle = 0
+bridge_flow_ratio = 0.8
+bridge_speed = 20
+brim_width = 0
+clip_multipart_objects = 1
+compatible_printers = 
+complete_objects = 0
+default_acceleration = 1000
+dont_support_bridges = 1
+elefant_foot_compensation = 0
+ensure_vertical_shell_thickness = 1
+external_fill_pattern = rectilinear
+external_perimeters_first = 0
+external_perimeter_extrusion_width = 0.45
+extra_perimeters = 0
+extruder_clearance_height = 20
+extruder_clearance_radius = 20
+extrusion_width = 0.45
+fill_angle = 45
+fill_density = 20%
+fill_pattern = cubic
+first_layer_acceleration = 1000
+first_layer_extrusion_width = 0.42
+first_layer_height = 0.2
+first_layer_speed = 30
+gap_fill_speed = 40
+gcode_comments = 0
+infill_every_layers = 1
+infill_extruder = 1
+infill_extrusion_width = 0.45
+infill_first = 0
+infill_only_where_needed = 0
+infill_overlap = 25%
+interface_shells = 0
+max_print_speed = 100
+max_volumetric_extrusion_rate_slope_negative = 0
+max_volumetric_extrusion_rate_slope_positive = 0
+max_volumetric_speed = 0
+min_skirt_length = 4
+notes = 
+overhangs = 0
+only_retract_when_crossing_perimeters = 0
+ooze_prevention = 0
+output_filename_format = [input_filename_base].gcode
+perimeters = 2
+perimeter_extruder = 1
+perimeter_extrusion_width = 0.45
+post_process = 
+print_settings_id = 
+raft_layers = 0
+resolution = 0
+seam_position = nearest
+skirts = 1
+skirt_distance = 2
+skirt_height = 3
+small_perimeter_speed = 25
+solid_infill_below_area = 0
+solid_infill_every_layers = 0
+solid_infill_extruder = 1
+solid_infill_extrusion_width = 0.45
+spiral_vase = 0
+standby_temperature_delta = -5
+support_material = 0
+support_material_extruder = 0
+support_material_extrusion_width = 0.35
+support_material_interface_extruder = 0
+support_material_angle = 0
+support_material_buildplate_only = 0
+support_material_enforce_layers = 0
+support_material_contact_distance = 0.15
+support_material_interface_contact_loops = 0
+support_material_interface_layers = 2
+support_material_interface_spacing = 0.2
+support_material_interface_speed = 100%
+support_material_pattern = rectilinear
+support_material_spacing = 2
+support_material_speed = 50
+support_material_synchronize_layers = 0
+support_material_threshold = 45
+support_material_with_sheath = 0
+support_material_xy_spacing = 60%
+thin_walls = 0
+top_infill_extrusion_width = 0.45
+top_solid_infill_speed = 40
+travel_speed = 180
+wipe_tower = 1
+wipe_tower_bridging = 10
+wipe_tower_rotation_angle = 0
+wipe_tower_width = 60
+wipe_tower_x = 180
+wipe_tower_y = 140
+xy_size_compensation = 0
+
+# Print parameters common to a 0.25mm diameter nozzle.
+[print:*0.25nozzle*]
+external_perimeter_extrusion_width = 0.25
+extrusion_width = 0.25
+first_layer_extrusion_width = 0.25
+infill_extrusion_width = 0.25
+perimeter_extrusion_width = 0.25
+solid_infill_extrusion_width = 0.25
+top_infill_extrusion_width = 0.25
+support_material_extrusion_width = 0.18
+support_material_interface_layers = 0
+support_material_interface_spacing = 0.15
+support_material_spacing = 1
+support_material_xy_spacing = 150%
+
+# Print parameters common to a 0.6mm diameter nozzle.
+[print:*0.6nozzle*]
+external_perimeter_extrusion_width = 0.61
+extrusion_width = 0.67
+first_layer_extrusion_width = 0.65
+infill_extrusion_width = 0.7
+perimeter_extrusion_width = 0.65
+solid_infill_extrusion_width = 0.65
+top_infill_extrusion_width = 0.6
+
+[print:*soluble_support*]
+overhangs = 1
+skirts = 0
+support_material = 1
+support_material_contact_distance = 0
+support_material_extruder = 4
+support_material_extrusion_width = 0.45
+support_material_interface_extruder = 4
+support_material_interface_spacing = 0.1
+support_material_synchronize_layers = 1
+support_material_threshold = 80
+support_material_with_sheath = 1
+wipe_tower = 1
+
+[print:*0.05mm*]
+inherits = *common*
+bottom_solid_layers = 10
+bridge_acceleration = 300
+bridge_flow_ratio = 0.7
+default_acceleration = 500
+external_perimeter_speed = 20
+fill_density = 20%
+first_layer_acceleration = 500
+gap_fill_speed = 20
+infill_acceleration = 800
+infill_speed = 30
+max_print_speed = 80
+small_perimeter_speed = 20
+solid_infill_speed = 30
+support_material_extrusion_width = 0.3
+support_material_spacing = 1.5
+layer_height = 0.05
+perimeter_acceleration = 300
+perimeter_speed = 30
+perimeters = 3
+support_material_speed = 30
+top_solid_infill_speed = 20
+top_solid_layers = 15
+
+[print:0.05mm ULTRADETAIL]
+inherits = *0.05mm*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.4 and num_extruders==1
+infill_extrusion_width = 0.5
+
+[print:0.05mm ULTRADETAIL MK3]
+inherits = *0.05mm*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK3.*/  and nozzle_diameter[0]==0.4
+fill_pattern = grid
+top_infill_extrusion_width = 0.4
+
+[print:0.05mm ULTRADETAIL 0.25 nozzle]
+inherits = *0.05mm*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.25 and num_extruders==1
+external_perimeter_extrusion_width = 0
+extrusion_width = 0.28
+fill_density = 20%
+first_layer_extrusion_width = 0.3
+infill_extrusion_width = 0
+infill_speed = 20
+max_print_speed = 100
+perimeter_extrusion_width = 0
+perimeter_speed = 20
+small_perimeter_speed = 15
+solid_infill_extrusion_width = 0
+solid_infill_speed = 20
+support_material_speed = 20
+top_infill_extrusion_width = 0
+
+[print:0.05mm ULTRADETAIL 0.25 nozzle MK3]
+inherits = *0.05mm*; *0.25nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK3.*/ and nozzle_diameter[0]==0.25 and num_extruders==1
+fill_pattern = grid
+top_infill_extrusion_width = 0.4
+
+[print:*0.10mm*]
+inherits = *common*
+bottom_solid_layers = 7
+bridge_flow_ratio = 0.7
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.4 and num_extruders==1
+layer_height = 0.1
+perimeter_acceleration = 800
+top_solid_layers = 9
+
+[print:0.10mm DETAIL]
+inherits = *0.10mm*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.4 and num_extruders==1
+external_perimeter_speed = 40
+infill_acceleration = 2000
+infill_speed = 60
+perimeter_speed = 50
+solid_infill_speed = 50
+
+[print:0.10mm DETAIL MK3]
+inherits = *0.10mm*
+bridge_speed = 30
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK3.*/ and nozzle_diameter[0]==0.4
+external_perimeter_speed = 35
+fill_pattern = grid
+infill_acceleration = 1500
+infill_speed = 170
+max_print_speed = 200
+perimeter_speed = 45
+solid_infill_speed = 170
+top_infill_extrusion_width = 0.4
+top_solid_infill_speed = 50
+
+[print:0.10mm DETAIL 0.25 nozzle]
+inherits = *0.10mm*
+bridge_acceleration = 600
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.25
+external_perimeter_speed = 20
+infill_acceleration = 1600
+infill_speed = 40
+perimeter_acceleration = 600
+perimeter_speed = 25
+small_perimeter_speed = 15
+solid_infill_speed = 40
+top_solid_infill_speed = 30
+
+[print:0.10mm DETAIL 0.25 nozzle MK3]
+inherits = *0.10mm*
+bridge_speed = 30
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK3.*/ and nozzle_diameter[0]==0.25
+external_perimeter_speed = 35
+fill_pattern = grid
+infill_acceleration = 1500
+infill_speed = 170
+max_print_speed = 200
+perimeter_speed = 45
+solid_infill_speed = 170
+top_infill_extrusion_width = 0.4
+top_solid_infill_speed = 50
+
+[print:0.10mm DETAIL 0.6 nozzle MK3]
+inherits = *0.10mm*
+bridge_speed = 30
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK3.*/ and nozzle_diameter[0]==0.6
+external_perimeter_speed = 35
+fill_pattern = grid
+infill_acceleration = 1500
+infill_speed = 170
+max_print_speed = 200
+perimeter_speed = 45
+solid_infill_speed = 170
+top_infill_extrusion_width = 0.4
+top_solid_infill_speed = 50
+
+[print:*0.15mm*]
+inherits = *common*
+bottom_solid_layers = 5
+external_perimeter_speed = 40
+infill_acceleration = 2000
+infill_speed = 60
+layer_height = 0.15
+perimeter_acceleration = 800
+perimeter_speed = 50
+solid_infill_speed = 50
+top_infill_extrusion_width = 0.4
+top_solid_layers = 7
+
+[print:0.15mm 100mms Linear Advance]
+inherits = *0.15mm*
+bridge_flow_ratio = 0.95
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.4
+external_perimeter_speed = 50
+infill_speed = 100
+max_print_speed = 150
+perimeter_speed = 60
+small_perimeter_speed = 30
+solid_infill_speed = 100
+support_material_speed = 60
+top_solid_infill_speed = 70
+
+[print:0.15mm OPTIMAL]
+inherits = *0.15mm*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.4
+top_infill_extrusion_width = 0.45
+
+[print:0.15mm OPTIMAL 0.25 nozzle]
+inherits = *0.15mm*; *0.25nozzle*
+bridge_acceleration = 600
+bridge_flow_ratio = 0.7
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.25
+external_perimeter_speed = 20
+infill_acceleration = 1600
+infill_speed = 40
+perimeter_acceleration = 600
+perimeter_speed = 25
+small_perimeter_speed = 15
+solid_infill_speed = 40
+support_material_extrusion_width = 0.2
+top_solid_infill_speed = 30
+
+[print:0.15mm OPTIMAL 0.6 nozzle]
+inherits = *0.15mm*; *0.6nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.6
+
+[print:0.15mm OPTIMAL MK3]
+inherits = *0.15mm*
+bridge_speed = 30
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK3.*/ and nozzle_diameter[0]==0.4
+external_perimeter_speed = 35
+fill_pattern = grid
+infill_acceleration = 1500
+infill_speed = 170
+max_print_speed = 170
+perimeter_speed = 45
+solid_infill_speed = 170
+top_solid_infill_speed = 50
+
+[print:0.15mm OPTIMAL SOLUBLE FULL]
+inherits = *0.15mm*; *soluble_support*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.4 and num_extruders>1
+external_perimeter_speed = 25
+notes = Set your solluble extruder in Multiple Extruders > Support material/raft/skirt extruder &  Support material/raft interface extruder
+perimeter_speed = 40
+solid_infill_speed = 40
+top_infill_extrusion_width = 0.45
+top_solid_infill_speed = 30
+wipe_tower = 1
+
+[print:0.15mm OPTIMAL SOLUBLE INTERFACE]
+inherits = 0.15mm OPTIMAL SOLUBLE FULL
+notes = Set your solluble extruder in Multiple Extruders >  Support material/raft interface extruder
+support_material_extruder = 0
+support_material_interface_layers = 3
+support_material_with_sheath = 0
+support_material_xy_spacing = 80%
+
+[print:0.15mm OPTIMAL 0.25 nozzle MK3]
+inherits = *0.15mm*
+bridge_speed = 30
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK3.*/ and nozzle_diameter[0]==0.25
+external_perimeter_speed = 35
+fill_pattern = grid
+infill_acceleration = 1500
+infill_speed = 170
+max_print_speed = 170
+perimeter_speed = 45
+solid_infill_speed = 170
+top_solid_infill_speed = 50
+[print:*0.20mm*]
+inherits = *common*
+bottom_solid_layers = 4
+bridge_flow_ratio = 0.95
+external_perimeter_speed = 40
+infill_acceleration = 2000
+infill_speed = 60
+layer_height = 0.2
+perimeter_acceleration = 800
+perimeter_speed = 50
+solid_infill_speed = 50
+top_infill_extrusion_width = 0.4
+top_solid_layers = 5
+
+[print:0.15mm OPTIMAL 0.6 nozzle MK3]
+inherits = *0.15mm*
+bridge_speed = 30
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK3.*/ and nozzle_diameter[0]==0.6
+external_perimeter_speed = 35
+fill_pattern = grid
+infill_acceleration = 1500
+infill_speed = 170
+max_print_speed = 170
+perimeter_speed = 45
+solid_infill_speed = 170
+top_solid_infill_speed = 50
+
+[print:0.20mm 100mms Linear Advance]
+inherits = *0.20mm*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.4
+external_perimeter_speed = 50
+infill_speed = 100
+max_print_speed = 150
+perimeter_speed = 60
+small_perimeter_speed = 30
+solid_infill_speed = 100
+support_material_speed = 60
+top_solid_infill_speed = 70
+
+[print:0.20mm FAST MK3]
+inherits = *0.20mm*
+bridge_speed = 30
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK3.*/ and nozzle_diameter[0]==0.4
+external_perimeter_speed = 35
+fill_pattern = grid
+infill_acceleration = 1500
+infill_speed = 170
+max_print_speed = 170
+perimeter_speed = 45
+solid_infill_speed = 170
+top_solid_infill_speed = 50
+
+[print:0.20mm NORMAL]
+inherits = *0.20mm*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.4
+
+[print:0.20mm NORMAL 0.6 nozzle]
+inherits = *0.20mm*; *0.6nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.6
+
+[print:0.20mm NORMAL SOLUBLE FULL]
+inherits = *0.20mm*; *soluble_support*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.4 and num_extruders>1
+external_perimeter_speed = 30
+notes = Set your solluble extruder in Multiple Extruders > Support material/raft/skirt extruder &  Support material/raft interface extruder
+perimeter_speed = 40
+solid_infill_speed = 40
+top_solid_infill_speed = 30
+
+[print:0.20mm NORMAL SOLUBLE INTERFACE]
+inherits = 0.20mm NORMAL SOLUBLE FULL
+notes = Set your solluble extruder in Multiple Extruders >  Support material/raft interface extruder
+support_material_extruder = 0
+support_material_interface_layers = 3
+support_material_with_sheath = 0
+support_material_xy_spacing = 80%
+
+[print:0.20mm FAST 0.6 nozzle MK3]
+inherits = *0.20mm*
+bridge_speed = 30
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK3.*/ and nozzle_diameter[0]==0.6
+external_perimeter_speed = 35
+fill_pattern = grid
+infill_acceleration = 1500
+infill_speed = 170
+max_print_speed = 170
+perimeter_speed = 45
+solid_infill_speed = 170
+top_solid_infill_speed = 50
+
+[print:*0.35mm*]
+inherits = *common*
+bottom_solid_layers = 3
+external_perimeter_extrusion_width = 0.6
+external_perimeter_speed = 40
+first_layer_extrusion_width = 0.75
+infill_acceleration = 2000
+infill_speed = 60
+layer_height = 0.35
+perimeter_acceleration = 800
+perimeter_extrusion_width = 0.65
+perimeter_speed = 50
+solid_infill_extrusion_width = 0.65
+solid_infill_speed = 60
+top_solid_infill_speed = 50
+top_solid_layers = 4
+
+[print:0.35mm FAST]
+inherits = *0.35mm*
+bridge_flow_ratio = 0.95
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.4
+first_layer_extrusion_width = 0.42
+perimeter_extrusion_width = 0.43
+solid_infill_extrusion_width = 0.7
+top_infill_extrusion_width = 0.43
+
+[print:0.35mm FAST 0.6 nozzle]
+inherits = *0.35mm*; *0.6nozzle*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.6
+
+[print:0.35mm FAST sol full 0.6 nozzle]
+inherits = *0.35mm*; *0.6nozzle*; *soluble_support*
+compatible_printers_condition = printer_notes=~/.*PRINTER_VENDOR_PRUSA3D.*/ and printer_notes=~/.*PRINTER_MODEL_MK2.*/ and nozzle_diameter[0]==0.6 and num_extruders>1
+external_perimeter_extrusion_width = 0.6
+external_perimeter_speed = 30
+notes = Set your solluble extruder in Multiple Extruders >  Support material/raft interface extruder
+perimeter_speed = 40
+support_material_extrusion_width = 0.55
+support_material_interface_layers = 3
+support_material_xy_spacing = 120%
+top_infill_extrusion_width = 0.57
+
+[print:0.35mm FAST sol int 0.6 nozzle]
+inherits = 0.35mm FAST sol full 0.6 nozzle
+support_material_extruder = 0
+support_material_interface_layers = 2
+support_material_with_sheath = 0
+support_material_xy_spacing = 150%
+
+[filament:*common*]
+cooling = 1
+compatible_printers = 
+compatible_printers_condition = 
+end_filament_gcode = "; Filament-specific end gcode"
+extrusion_multiplier = 1
+filament_loading_speed = 28
+filament_unloading_speed = 90
+filament_toolchange_delay = 0
+filament_ramming_parameters = "120 100 6.6 6.8 7.2 7.6 7.9 8.2 8.7 9.4 9.9 10.0| 0.05 6.6 0.45 6.8 0.95 7.8 1.45 8.3 1.95 9.7 2.45 10 2.95 7.6 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+filament_cost = 0
+filament_density = 0
+filament_diameter = 1.75
+filament_notes = ""
+filament_settings_id = 
+filament_soluble = 0
+min_print_speed = 15
+slowdown_below_layer_time = 20
+start_filament_gcode = "M900 K{if printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}200{else}30{endif}; Filament gcode"
+
+[filament:*PLA*]
+inherits = *common*
+bed_temperature = 60
+bridge_fan_speed = 100
+disable_fan_first_layers = 1
+fan_always_on = 1
+fan_below_layer_time = 100
+filament_colour = #FF3232
+filament_max_volumetric_speed = 15
+filament_type = PLA
+first_layer_bed_temperature = 60
+first_layer_temperature = 215
+max_fan_speed = 100
+min_fan_speed = 100
+temperature = 210
+
+[filament:*PET*]
+inherits = *common*
+bed_temperature = 90
+bridge_fan_speed = 50
+disable_fan_first_layers = 3
+fan_always_on = 1
+fan_below_layer_time = 20
+filament_colour = #FF8000
+filament_max_volumetric_speed = 8
+filament_type = PET
+first_layer_bed_temperature = 85
+first_layer_temperature = 230
+max_fan_speed = 50
+min_fan_speed = 30
+start_filament_gcode = "M900 K{if printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}200{else}45{endif}; Filament gcode"
+temperature = 240
+
+[filament:*ABS*]
+inherits = *common*
+bed_temperature = 110
+bridge_fan_speed = 30
+cooling = 0
+disable_fan_first_layers = 3
+fan_always_on = 0
+fan_below_layer_time = 20
+filament_colour = #3A80CA
+filament_max_volumetric_speed = 11
+filament_ramming_parameters = "120 100 5.70968 6.03226 7 8.25806 9 9.19355 9.3871 9.77419 10.129 10.3226 10.4516 10.5161| 0.05 5.69677 0.45 6.15484 0.95 8.76774 1.45 9.20323 1.95 9.95806 2.45 10.3871 2.95 10.5677 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+filament_type = ABS
+first_layer_bed_temperature = 100
+first_layer_temperature = 255
+max_fan_speed = 30
+min_fan_speed = 20
+temperature = 255
+
+[filament:*FLEX*]
+inherits = *common*
+bed_temperature = 50
+bridge_fan_speed = 100
+compatible_printers_condition = nozzle_diameter[0]>0.35 and num_extruders==1
+cooling = 0
+disable_fan_first_layers = 1
+extrusion_multiplier = 1.2
+fan_always_on = 0
+fan_below_layer_time = 100
+filament_colour = #00CA0A
+filament_max_volumetric_speed = 1.5
+filament_type = FLEX
+first_layer_bed_temperature = 50
+first_layer_temperature = 240
+max_fan_speed = 90
+min_fan_speed = 70
+start_filament_gcode = "M900 K{if printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}200{else}10{endif}; Filament gcode"
+temperature = 240
+
+[filament:ColorFabb Brass Bronze]
+inherits = *PLA*
+compatible_printers_condition = nozzle_diameter[0]>0.35
+extrusion_multiplier = 1.2
+filament_colour = #804040
+filament_max_volumetric_speed = 10
+
+[filament:ColorFabb HT]
+inherits = *PET*
+bed_temperature = 110
+bridge_fan_speed = 30
+cooling = 1
+disable_fan_first_layers = 3
+fan_always_on = 0
+fan_below_layer_time = 10
+first_layer_bed_temperature = 105
+first_layer_temperature = 270
+max_fan_speed = 20
+min_fan_speed = 10
+start_filament_gcode = "M900 K{if printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}200{else}45{endif}; Filament gcode"
+temperature = 270
+
+[filament:ColorFabb PLA-PHA]
+inherits = *PLA*
+
+[filament:ColorFabb Woodfil]
+inherits = *PLA*
+compatible_printers_condition = nozzle_diameter[0]>0.35
+extrusion_multiplier = 1.2
+filament_colour = #804040
+filament_max_volumetric_speed = 10
+first_layer_temperature = 200
+start_filament_gcode = "M900 K{if printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}200{else}10{endif}; Filament gcode"
+temperature = 200
+
+[filament:ColorFabb XT]
+inherits = *PET*
+filament_type = PLA
+first_layer_bed_temperature = 90
+first_layer_temperature = 260
+temperature = 270
+
+[filament:ColorFabb XT-CF20]
+inherits = *PET*
+extrusion_multiplier = 1.2
+filament_colour = #804040
+filament_max_volumetric_speed = 1
+first_layer_bed_temperature = 90
+first_layer_temperature = 260
+start_filament_gcode = "M900 K{if printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}200{else}30{endif}; Filament gcode"
+temperature = 260
+
+[filament:ColorFabb nGen]
+inherits = *PET*
+bridge_fan_speed = 40
+fan_always_on = 0
+fan_below_layer_time = 10
+filament_type = NGEN
+first_layer_temperature = 240
+max_fan_speed = 35
+min_fan_speed = 20
+
+[filament:ColorFabb nGen flex]
+inherits = *FLEX*
+bed_temperature = 85
+bridge_fan_speed = 40
+cooling = 1
+disable_fan_first_layers = 3
+extrusion_multiplier = 1
+fan_below_layer_time = 10
+filament_max_volumetric_speed = 5
+first_layer_bed_temperature = 85
+first_layer_temperature = 260
+max_fan_speed = 35
+min_fan_speed = 20
+temperature = 260
+
+[filament:E3D Edge]
+inherits = *PET*
+filament_notes = "List of manufacturers tested with standart PET print settings for MK2:\n\nE3D Edge\nFillamentum CPE GH100\nPlasty Mladeč PETG"
+
+[filament:E3D PC-ABS]
+inherits = *ABS*
+first_layer_temperature = 270
+temperature = 270
+
+[filament:Fillamentum ABS]
+inherits = *ABS*
+first_layer_temperature = 240
+temperature = 240
+
+[filament:Fillamentum ASA]
+inherits = *ABS*
+fan_always_on = 1
+first_layer_temperature = 265
+temperature = 265
+
+[filament:Fillamentum CPE HG100 HM100]
+inherits = *PET*
+filament_notes = "CPE HG100 , CPE HM100"
+first_layer_bed_temperature = 90
+first_layer_temperature = 275
+max_fan_speed = 50
+min_fan_speed = 50
+temperature = 275
+
+[filament:Fillamentum Timberfil]
+inherits = *PLA*
+compatible_printers_condition = nozzle_diameter[0]>0.35
+extrusion_multiplier = 1.2
+filament_colour = #804040
+filament_max_volumetric_speed = 10
+first_layer_temperature = 190
+start_filament_gcode = "M900 K{if printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}200{else}10{endif}; Filament gcode"
+temperature = 190
+
+[filament:Generic ABS]
+inherits = *ABS*
+filament_notes = "List of materials tested with standart ABS print settings for MK2:\n\nEsun ABS\nFil-A-Gehr ABS\nHatchboxABS\nPlasty Mladeč ABS"
+
+[filament:Generic PET]
+inherits = *PET*
+filament_notes = "List of manufacturers tested with standart PET print settings for MK2:\n\nE3D Edge\nFillamentum CPE GH100\nPlasty Mladeč PETG"
+
+[filament:Generic PLA]
+inherits = *PLA*
+filament_notes = "List of materials tested with standart PLA print settings for MK2:\n\nDas Filament\nEsun PLA\nEUMAKERS PLA\nFiberlogy HD-PLA\nFillamentum PLA\nFloreon3D\nHatchbox PLA\nPlasty Mladeč PLA\nPrimavalue PLA\nProto pasta Matte Fiber\nVerbatim PLA\nVerbatim BVOH"
+
+[filament:Polymaker PC-Max]
+inherits = *ABS*
+bed_temperature = 115
+filament_colour = #3A80CA
+first_layer_bed_temperature = 100
+first_layer_temperature = 270
+temperature = 270
+
+[filament:Primavalue PVA]
+inherits = *PLA*
+cooling = 0
+fan_always_on = 0
+filament_colour = #FFFFD7
+filament_max_volumetric_speed = 10
+filament_notes = "List of materials tested with standart PVA print settings for MK2:\n\nPrimaSelect PVA+\nICE FILAMENTS PVA 'NAUGHTY NATURAL'\nVerbatim BVOH"
+filament_ramming_parameters = "120 100 8.3871 8.6129 8.93548 9.22581 9.48387 9.70968 9.87097 10.0323 10.2258 10.4194 10.6452 10.8065| 0.05 8.34193 0.45 8.73548 0.95 9.34836 1.45 9.78385 1.95 10.0871 2.45 10.5161 2.95 10.8903 3.45 7.6 3.95 7.6 4.45 7.6 4.95 7.6"
+filament_soluble = 1
+filament_type = PVA
+first_layer_temperature = 195
+start_filament_gcode = "M900 K{if printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}200{else}10{endif}; Filament gcode"
+temperature = 195
+
+[filament:Prusa ABS]
+inherits = *ABS*
+filament_notes = "List of materials tested with standart ABS print settings for MK2:\n\nEsun ABS\nFil-A-Gehr ABS\nHatchboxABS\nPlasty Mladeč ABS"
+
+[filament:Prusa HIPS]
+inherits = *ABS*
+bridge_fan_speed = 50
+cooling = 1
+extrusion_multiplier = 0.9
+fan_always_on = 1
+fan_below_layer_time = 10
+filament_colour = #FFFFD7
+filament_soluble = 1
+filament_type = HIPS
+first_layer_temperature = 220
+max_fan_speed = 20
+min_fan_speed = 20
+start_filament_gcode = "M900 K{if printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}200{else}10{endif}; Filament gcode"
+temperature = 220
+
+[filament:Prusa PET]
+inherits = *PET*
+filament_notes = "List of manufacturers tested with standart PET print settings for MK2:\n\nE3D Edge\nFillamentum CPE GH100\nPlasty Mladeč PETG"
+
+[filament:Prusa PLA]
+inherits = *PLA*
+filament_notes = "List of materials tested with standart PLA print settings for MK2:\n\nDas Filament\nEsun PLA\nEUMAKERS PLA\nFiberlogy HD-PLA\nFillamentum PLA\nFloreon3D\nHatchbox PLA\nPlasty Mladeč PLA\nPrimavalue PLA\nProto pasta Matte Fiber\nVerbatim PLA\nVerbatim BVOH"
+
+[filament:SemiFlex or Flexfill 98A]
+inherits = *FLEX*
+
+[filament:Taulman Bridge]
+inherits = *common*
+bed_temperature = 90
+bridge_fan_speed = 40
+cooling = 0
+disable_fan_first_layers = 3
+fan_always_on = 0
+fan_below_layer_time = 20
+filament_colour = #DEE0E6
+filament_max_volumetric_speed = 10
+filament_soluble = 0
+filament_type = PET
+first_layer_bed_temperature = 60
+first_layer_temperature = 240
+max_fan_speed = 5
+min_fan_speed = 0
+start_filament_gcode = "M900 K{if printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}200{else}10{endif}; Filament gcode"
+temperature = 250
+
+[filament:Taulman T-Glase]
+inherits = *PET*
+bridge_fan_speed = 40
+cooling = 0
+fan_always_on = 0
+first_layer_bed_temperature = 90
+first_layer_temperature = 240
+max_fan_speed = 5
+min_fan_speed = 0
+start_filament_gcode = "M900 K{if printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}200{else}30{endif}; Filament gcode"
+
+[filament:Verbatim BVOH]
+inherits = *common*
+bed_temperature = 60
+bridge_fan_speed = 100
+cooling = 0
+disable_fan_first_layers = 1
+extrusion_multiplier = 1
+fan_always_on = 0
+fan_below_layer_time = 100
+filament_colour = #FFFFD7
+filament_max_volumetric_speed = 10
+filament_notes = "List of materials tested with standart PLA print settings for MK2:\n\nDas Filament\nEsun PLA\nEUMAKERS PLA\nFiberlogy HD-PLA\nFillamentum PLA\nFloreon3D\nHatchbox PLA\nPlasty Mladeč PLA\nPrimavalue PLA\nProto pasta Matte Fiber\nVerbatim PLA\nVerbatim BVOH"
+filament_soluble = 1
+filament_type = PLA
+first_layer_bed_temperature = 60
+first_layer_temperature = 215
+max_fan_speed = 100
+min_fan_speed = 100
+start_filament_gcode = "M900 K{if printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}200{else}10{endif}; Filament gcode"
+temperature = 210
+
+[filament:Verbatim PP]
+inherits = *common*
+bed_temperature = 100
+bridge_fan_speed = 100
+cooling = 1
+disable_fan_first_layers = 2
+extrusion_multiplier = 1
+fan_always_on = 1
+fan_below_layer_time = 100
+filament_colour = #DEE0E6
+filament_max_volumetric_speed = 5
+filament_notes = "List of materials tested with standart PLA print settings for MK2:\n\nEsun PLA\nFiberlogy HD-PLA\nFillamentum PLA\nFloreon3D\nHatchbox PLA\nPlasty Mladeč PLA\nPrimavalue PLA\nProto pasta Matte Fiber\nEUMAKERS PLA"
+filament_type = PLA
+first_layer_bed_temperature = 100
+first_layer_temperature = 220
+max_fan_speed = 100
+min_fan_speed = 100
+start_filament_gcode = "M900 K{if printer_notes=~/.*PRINTER_HAS_BOWDEN.*/}200{else}10{endif}; Filament gcode"
+temperature = 220
+
+[printer:*common*]
+bed_shape = 0x0,250x0,250x210,0x210
+before_layer_gcode = ;BEFORE_LAYER_CHANGE\n;[layer_z]\n\n
+between_objects_gcode = 
+deretract_speed = 0
+end_gcode = G4 ; wait\nM104 S0 ; turn off temperature\nM140 S0 ; turn off heatbed\nM107 ; turn off fan\nG1 X0 Y200; home X axis\nM84 ; disable motors
+extruder_colour = #FFFF00
+extruder_offset = 0x0
+gcode_flavor = marlin
+layer_gcode = ;AFTER_LAYER_CHANGE\n;[layer_z]
+max_layer_height = 0.25
+min_layer_height = 0.07
+max_print_height = 200
+nozzle_diameter = 0.4
+octoprint_apikey = 
+octoprint_host = 
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_PRUSA3D\nPRINTER_MODEL_MK2\n
+printer_settings_id = 
+retract_before_travel = 1
+retract_before_wipe = 0%
+retract_layer_change = 1
+retract_length = 0.8
+retract_length_toolchange = 4
+retract_lift = 0.6
+retract_lift_above = 0
+retract_lift_below = 199
+retract_restart_extra = 0
+retract_restart_extra_toolchange = 0
+retract_speed = 35
+serial_port = 
+serial_speed = 250000
+single_extruder_multi_material = 0
+start_gcode = M115 U3.1.0 ; tell printer latest fw version\nM201 X9000 Y9000 Z500 E10000 ; sets maximum accelerations, mm/sec^2\nM203 X500 Y500 Z12 E120 ; sets maximum feedrates, mm/sec\nM204 S1500 T1500 ; sets acceleration (S) and retract acceleration (T)\nM205 X10 Y10 Z0.2 E2.5 ; sets the jerk limits, mm/sec\nM205 S0 T0 ; sets the minimum extruding and travel feed rate, mm/sec\nM83  ; extruder relative mode\nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG28 W ; home all without mesh bed level\nG80 ; mesh bed leveling\nG1 Y-3.0 F1000.0 ; go outside print area\nG92 E0.0\nG1 X60.0 E9.0  F1000.0 ; intro line\nG1 X100.0 E12.5  F1000.0 ; intro line\nG92 E0.0
+toolchange_gcode = 
+use_firmware_retraction = 0
+use_relative_e_distances = 1
+use_volumetric_e = 0
+variable_layer_height = 1
+wipe = 1
+z_offset = 0
+printer_model = MK2S
+printer_variant = 0.4
+default_print_profile = 0.15mm OPTIMAL
+default_filament_profile = Prusa PLA
+
+[printer:*multimaterial*]
+inherits = *common*
+deretract_speed = 50
+retract_before_travel = 3
+retract_before_wipe = 60%
+retract_layer_change = 0
+retract_length = 4
+retract_lift = 0.6
+retract_lift_above = 0
+retract_lift_below = 199
+retract_restart_extra = 0
+retract_restart_extra_toolchange = 0
+retract_speed = 80
+parking_pos_retraction = 92
+cooling_tube_length = 5
+cooling_tube_retraction = 91.5
+single_extruder_multi_material = 1
+printer_model = MK2SMM
+
+[printer:*mm-single*]
+inherits = *multimaterial*
+end_gcode = G1 E-4 F2100.00000\nG91\nG1 Z1 F7200.000\nG90\nG1 X245 Y1\nG1 X240 E4\nG1 F4000\nG1 X190 E2.7  \nG1 F4600\nG1 X110 E2.8\nG1 F5200\nG1 X40 E3  \nG1 E-15.0000 F5000\nG1 E-50.0000 F5400\nG1 E-15.0000 F3000\nG1 E-12.0000 F2000\nG1 F1600\nG1 X0 Y1 E3.0000\nG1 X50 Y1 E-5.0000\nG1 F2000\nG1 X0 Y1 E5.0000\nG1 X50 Y1 E-5.0000\nG1 F2400\nG1 X0 Y1 E5.0000\nG1 X50 Y1 E-5.0000\nG1 F2400\nG1 X0 Y1 E5.0000\nG1 X50 Y1 E-3.0000\nG4 S0\nM107 ; fan off\nM104 S0 ; turn off temperature\nM140 S0 ; turn off heatbed\nG28 X0  ; home X axis\nM84     ; disable motors\n\n
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_PRUSA3D\nPRINTER_MODEL_MK2\nPRINTER_HAS_BOWDEN
+start_gcode = M115 U3.1.0 ; tell printer latest fw version\nM201 X9000 Y9000 Z500 E10000 ; sets maximum accelerations, mm/sec^2\nM203 X500 Y500 Z12 E120 ; sets maximum feedrates, mm/sec\nM204 S1500 T1500 ; sets acceleration (S) and retract acceleration (T)\nM205 X10 Y10 Z0.2 E2.5 ; sets the jerk limits, mm/sec\nM205 S0 T0 ; sets the minimum extruding and travel feed rate, mm/sec\n; Start G-Code sequence START\nT?\nM104 S[first_layer_temperature]\nM140 S[first_layer_bed_temperature]\nM109 S[first_layer_temperature]\nM190 S[first_layer_bed_temperature]\nG21 ; set units to millimeters\nG90 ; use absolute coordinates\nM83 ; use relative distances for extrusion\nG28 W\nG80\nG92 E0.0\nM203 E100\nM92 E140\nG1 Z0.250 F7200.000\nG1 X50.0 E80.0  F1000.0\nG1 X160.0 E20.0  F1000.0\nG1 Z0.200 F7200.000\nG1 X220.0 E13 F1000.0\nG1 X240.0 E0 F1000.0\nG1 E-4 F1000.0\nG92 E0.0
+default_print_profile = 0.15mm OPTIMAL
+default_filament_profile = Prusa PLA
+
+[printer:*mm-multi*]
+inherits = *multimaterial*
+end_gcode = {if not has_wipe_tower}\n; Pull the filament into the cooling tubes.\nG1 E-4 F2100.00000\nG91\nG1 Z1 F7200.000\nG90\nG1 X245 Y1\nG1 X240 E4\nG1 F4000\nG1 X190 E2.7  \nG1 F4600\nG1 X110 E2.8\nG1 F5200\nG1 X40 E3  \nG1 E-15.0000 F5000\nG1 E-50.0000 F5400\nG1 E-15.0000 F3000\nG1 E-12.0000 F2000\nG1 F1600\nG1 X0 Y1 E3.0000\nG1 X50 Y1 E-5.0000\nG1 F2000\nG1 X0 Y1 E5.0000\nG1 X50 Y1 E-5.0000\nG1 F2400\nG1 X0 Y1 E5.0000\nG1 X50 Y1 E-5.0000\nG1 F2400\nG1 X0 Y1 E5.0000\nG1 X50 Y1 E-3.0000\nG4 S0\n{endif}\nM107 ; fan off\nM104 S0 ; turn off temperature\nM140 S0 ; turn off heatbed\nG28 X0  ; home X axis\nM84     ; disable motors
+extruder_colour = #FFAA55;#5182DB;#4ECDD3;#FB7259
+nozzle_diameter = 0.4,0.4,0.4,0.4
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_PRUSA3D\nPRINTER_MODEL_MK2\nPRINTER_HAS_BOWDEN
+start_gcode = M115 U3.1.0 ; tell printer latest fw version\nM201 X9000 Y9000 Z500 E10000 ; sets maximum accelerations, mm/sec^2\nM203 X500 Y500 Z12 E120 ; sets maximum feedrates, mm/sec\nM204 S1500 T1500 ; sets acceleration (S) and retract acceleration (T)\nM205 X10 Y10 Z0.2 E2.5 ; sets the jerk limits, mm/sec\nM205 S0 T0 ; sets the minimum extruding and travel feed rate, mm/sec\n; Start G-Code sequence START\nT[initial_tool]\nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG21 ; set units to millimeters\nG90 ; use absolute coordinates\nM83 ; use relative distances for extrusion\nG28 W\nG80\nG92 E0.0\nM203 E100 ; set max feedrate\nM92 E140 ; E-steps per filament milimeter\n{if not has_wipe_tower}\nG1 Z0.250 F7200.000\nG1 X50.0 E80.0  F1000.0\nG1 X160.0 E20.0  F1000.0\nG1 Z0.200 F7200.000\nG1 X220.0 E13 F1000.0\nG1 X240.0 E0 F1000.0\nG1 E-4 F1000.0\n{endif}\nG92 E0.0
+variable_layer_height = 0
+default_print_profile = 0.15mm OPTIMAL
+default_filament_profile = Prusa PLA
+
+[printer:Original Prusa i3 MK2]
+inherits = *common*
+
+[printer:Original Prusa i3 MK2 0.25 nozzle]
+inherits = *common*
+max_layer_height = 0.1
+min_layer_height = 0.05
+nozzle_diameter = 0.25
+retract_length = 1
+retract_speed = 50
+variable_layer_height = 0
+printer_variant = 0.25
+default_print_profile = 0.10mm DETAIL 0.25 nozzle
+
+[printer:Original Prusa i3 MK2 0.6 nozzle]
+inherits = *common*
+max_layer_height = 0.35
+min_layer_height = 0.1
+nozzle_diameter = 0.6
+printer_variant = 0.6
+default_print_profile = 0.20mm NORMAL 0.6 nozzle
+
+[printer:Original Prusa i3 MK2 MM Single Mode]
+inherits = *mm-single*
+
+[printer:Original Prusa i3 MK2 MM Single Mode 0.6 nozzle]
+inherits = *mm-single*
+nozzle_diameter = 0.6
+printer_variant = 0.6
+default_print_profile = 0.20mm NORMAL 0.6 nozzle
+
+[printer:Original Prusa i3 MK2 MultiMaterial]
+inherits = *mm-multi*
+nozzle_diameter = 0.4,0.4,0.4,0.4
+
+[printer:Original Prusa i3 MK2 MultiMaterial 0.6 nozzle]
+inherits = *mm-multi*
+nozzle_diameter = 0.6,0.6,0.6,0.6
+printer_variant = 0.6
+default_print_profile = 0.20mm NORMAL 0.6 nozzle
+
+[printer:Original Prusa i3 MK3]
+inherits = *common*
+end_gcode = G4 ; wait\nM221 S100\nM104 S0 ; turn off temperature\nM140 S0 ; turn off heatbed\nM107 ; turn off fan\nG1 X0 Y200; home X axis\nM84 ; disable motors
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_PRUSA3D\nPRINTER_MODEL_MK3\n
+retract_lift_below = 209
+max_print_height = 210
+start_gcode = M115 U3.1.1-RC5 ; tell printer latest fw version\nM201 X1000 Y1000 Z200 E5000 ; sets maximum accelerations, mm/sec^2\nM203 X200 Y200 Z12 E120 ; sets maximum feedrates, mm/sec\nM204 S1250 T1250 ; sets acceleration (S) and retract acceleration (T)\nM205 X10 Y10 Z0.4 E2.5 ; sets the jerk limits, mm/sec\nM205 S0 T0 ; sets the minimum extruding and travel feed rate, mm/sec\nM83  ; extruder relative mode\nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG28 W ; home all without mesh bed level\nG80 ; mesh bed leveling\nG1 Y-3.0 F1000.0 ; go outside print area\nG92 E0.0\nG1 X60.0 E9.0  F1000.0 ; intro line\nG1 X100.0 E12.5  F1000.0 ; intro line\nG92 E0.0\nM221 S{if layer_height==0.05}100{else}95{endif}
+printer_model = MK3
+default_print_profile = 0.15mm OPTIMAL MK3
+
+[printer:Original Prusa i3 MK3 0.25 nozzle]
+inherits = *common*
+nozzle_diameter = 0.25
+end_gcode = G4 ; wait\nM221 S100\nM104 S0 ; turn off temperature\nM140 S0 ; turn off heatbed\nM107 ; turn off fan\nG1 X0 Y200; home X axis\nM84 ; disable motors
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_PRUSA3D\nPRINTER_MODEL_MK3\n
+retract_lift_below = 209
+max_print_height = 210
+start_gcode = M115 U3.1.1-RC5 ; tell printer latest fw version\nM201 X1000 Y1000 Z200 E5000 ; sets maximum accelerations, mm/sec^2\nM203 X200 Y200 Z12 E120 ; sets maximum feedrates, mm/sec\nM204 S1250 T1250 ; sets acceleration (S) and retract acceleration (T)\nM205 X10 Y10 Z0.4 E2.5 ; sets the jerk limits, mm/sec\nM205 S0 T0 ; sets the minimum extruding and travel feed rate, mm/sec\nM83  ; extruder relative mode\nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG28 W ; home all without mesh bed level\nG80 ; mesh bed leveling\nG1 Y-3.0 F1000.0 ; go outside print area\nG92 E0.0\nG1 X60.0 E9.0  F1000.0 ; intro line\nG1 X100.0 E12.5  F1000.0 ; intro line\nG92 E0.0\nM221 S{if layer_height==0.05}100{else}95{endif}
+printer_model = MK3
+printer_variant = 0.25
+default_print_profile = 0.10mm DETAIL 0.25 nozzle MK3
+
+[printer:Original Prusa i3 MK3 0.6 nozzle]
+inherits = *common*
+nozzle_diameter = 0.6
+end_gcode = G4 ; wait\nM221 S100\nM104 S0 ; turn off temperature\nM140 S0 ; turn off heatbed\nM107 ; turn off fan\nG1 X0 Y200; home X axis\nM84 ; disable motors
+printer_notes = Don't remove the following keywords! These keywords are used in the "compatible printer" condition of the print and filament profiles to link the particular print and filament profiles to this printer profile.\nPRINTER_VENDOR_PRUSA3D\nPRINTER_MODEL_MK3\n
+retract_lift_below = 209
+max_print_height = 210
+start_gcode = M115 U3.1.1-RC5 ; tell printer latest fw version\nM201 X1000 Y1000 Z200 E5000 ; sets maximum accelerations, mm/sec^2\nM203 X200 Y200 Z12 E120 ; sets maximum feedrates, mm/sec\nM204 S1250 T1250 ; sets acceleration (S) and retract acceleration (T)\nM205 X10 Y10 Z0.4 E2.5 ; sets the jerk limits, mm/sec\nM205 S0 T0 ; sets the minimum extruding and travel feed rate, mm/sec\nM83  ; extruder relative mode\nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG28 W ; home all without mesh bed level\nG80 ; mesh bed leveling\nG1 Y-3.0 F1000.0 ; go outside print area\nG92 E0.0\nG1 X60.0 E9.0  F1000.0 ; intro line\nG1 X100.0 E12.5  F1000.0 ; intro line\nG92 E0.0\nM221 S{if layer_height==0.05}100{else}95{endif}
+printer_model = MK3
+printer_variant = 0.6
+default_print_profile = 0.15mm OPTIMAL 0.6 nozzle MK3
+
+# The obsolete presets will be removed when upgrading from the legacy configuration structure (up to Slic3r 1.39.2) to 1.40.0 and newer.
+[obsolete_presets]
+print="0.05mm DETAIL 0.25 nozzle";"0.05mm DETAIL MK3";"0.05mm DETAIL";"0.20mm NORMAL MK3";"0.35mm FAST MK3"
+filament="ColorFabb Brass Bronze  1.75mm";"ColorFabb HT 1.75mm";"ColorFabb nGen 1.75mm";"ColorFabb Woodfil 1.75mm";"ColorFabb XT 1.75mm";"ColorFabb XT-CF20 1.75mm";"E3D PC-ABS 1.75mm";"Fillamentum ABS 1.75mm";"Fillamentum ASA 1.75mm";"Generic ABS 1.75mm";"Generic PET 1.75mm";"Generic PLA 1.75mm";"Prusa ABS 1.75mm";"Prusa HIPS 1.75mm";"Prusa PET 1.75mm";"Prusa PLA 1.75mm";"Taulman Bridge 1.75mm";"Taulman T-Glase 1.75mm"

--- a/live/PrusaResearch/index.idx
+++ b/live/PrusaResearch/index.idx
@@ -1,3 +1,4 @@
+0.1.4 Fixed MK3 printer_variant fields, MK2 name
 0.1.3 Fixed an incorrect position of the max_print_height parameter
 0.1.2 Wipe tower changes
 0.1.1 Minor print speed adjustments


### PR DESCRIPTION
@jindrichbenes @bubnikv 

Diff of the bundle:

```diff
--- 0.1.3.ini	2018-05-31 12:22:37.215367530 +0200
+++ 0.1.4.ini	2018-05-31 12:29:03.325857503 +0200
@@ -5,7 +5,7 @@
 name = Prusa Research
 # Configuration version of this file. Config file will only be installed, if the config_version differs.
 # This means, the server may force the Slic3r configuration to be downgraded.
-config_version = 0.1.3
+config_version = 0.1.4
 # Where to get the updates from?
 config_update_url = https://raw.githubusercontent.com/prusa3d/Slic3r-settings/master/live/PrusaResearch/
 
@@ -19,7 +19,7 @@
 variants = 0.4; 0.25; 0.6
 
 [printer_model:MK2S]
-name = Original Prusa i3 MK2S
+name = Original Prusa i3 MK2S, MK2.5
 variants = 0.4; 0.25; 0.6
 
 [printer_model:MK2SMM]
@@ -1018,6 +1018,7 @@
 max_print_height = 210
 start_gcode = M115 U3.1.1-RC5 ; tell printer latest fw version\nM201 X1000 Y1000 Z200 E5000 ; sets maximum accelerations, mm/sec^2\nM203 X200 Y200 Z12 E120 ; sets maximum feedrates, mm/sec\nM204 S1250 T1250 ; sets acceleration (S) and retract acceleration (T)\nM205 X10 Y10 Z0.4 E2.5 ; sets the jerk limits, mm/sec\nM205 S0 T0 ; sets the minimum extruding and travel feed rate, mm/sec\nM83  ; extruder relative mode\nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG28 W ; home all without mesh bed level\nG80 ; mesh bed leveling\nG1 Y-3.0 F1000.0 ; go outside print area\nG92 E0.0\nG1 X60.0 E9.0  F1000.0 ; intro line\nG1 X100.0 E12.5  F1000.0 ; intro line\nG92 E0.0\nM221 S{if layer_height==0.05}100{else}95{endif}
 printer_model = MK3
+printer_variant = 0.25
 default_print_profile = 0.10mm DETAIL 0.25 nozzle MK3
 
 [printer:Original Prusa i3 MK3 0.6 nozzle]
@@ -1029,6 +1030,7 @@
 max_print_height = 210
 start_gcode = M115 U3.1.1-RC5 ; tell printer latest fw version\nM201 X1000 Y1000 Z200 E5000 ; sets maximum accelerations, mm/sec^2\nM203 X200 Y200 Z12 E120 ; sets maximum feedrates, mm/sec\nM204 S1250 T1250 ; sets acceleration (S) and retract acceleration (T)\nM205 X10 Y10 Z0.4 E2.5 ; sets the jerk limits, mm/sec\nM205 S0 T0 ; sets the minimum extruding and travel feed rate, mm/sec\nM83  ; extruder relative mode\nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG28 W ; home all without mesh bed level\nG80 ; mesh bed leveling\nG1 Y-3.0 F1000.0 ; go outside print area\nG92 E0.0\nG1 X60.0 E9.0  F1000.0 ; intro line\nG1 X100.0 E12.5  F1000.0 ; intro line\nG92 E0.0\nM221 S{if layer_height==0.05}100{else}95{endif}
 printer_model = MK3
+printer_variant = 0.6
 default_print_profile = 0.15mm OPTIMAL 0.6 nozzle MK3
 
 # The obsolete presets will be removed when upgrading from the legacy configuration structure (up to Slic3r 1.39.2) to 1.40.0 and newer.
```